### PR TITLE
fixed game_mode & game_type parameter

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,4 +63,4 @@ cp ${STEAMCMD_DIR}/linux32/steamclient.so ${STEAM_DIR}/.steam/sdk32/steamclient.
 cp ${STEAMCMD_DIR}/linux64/steamclient.so ${STEAM_DIR}/.steam/sdk64/steamclient.so
 
 # Start gameserver
-${CS2_DIR}/game/cs2.sh +ip ${IP} -port ${PORT} -dedicated -game csgo -console -usercon +map ${MAP} +gametype ${GAME_TYPE} +gamemode ${GAME_MODE} +exec autoexec.cfg ${EXTRAARG}
+${CS2_DIR}/game/cs2.sh +ip ${IP} -port ${PORT} -dedicated -game csgo -console -usercon +map ${MAP} +game_type ${GAME_TYPE} +game_mode ${GAME_MODE} +exec autoexec.cfg ${EXTRAARG}


### PR DESCRIPTION
The correct parameter names are 'game_mode' and 'game_type'.

With "gamemode" and "gametype", the container log prints errors about unknown parameters and the game is always in competitive mode.